### PR TITLE
Added __$e parameter to callbacks + fixed typos in function names + streamline integration

### DIFF
--- a/lib/spoon/block.js
+++ b/lib/spoon/block.js
@@ -93,7 +93,7 @@ Block.prototype.distance = function distance(to) {
   return best ? best.path : Infinity;
 };
 
-Block.prototype.split = function split(at, root, asyncify) {
+Block.prototype.split = function split(at, root, asyncify, marker) {
   var index = this.instructions.indexOf(at),
       head = this.instructions.slice(0, index),
       tail = this.instructions.slice(asyncify ? index + 1 : index);
@@ -114,13 +114,15 @@ Block.prototype.split = function split(at, root, asyncify) {
   var fn = root.prepend('fn', [ next ]);
 
   fn.name = '__$fn' + next.id;
-  fn.params = ['__$r'];
+  fn.params = ['__$e', '__$r'];
   fn.isExpression = false;
+  next.instructions = [this.add('async-test-err')].concat(next.instructions);
 
   this.ended = false;
 
   if (asyncify) {
-    at.args.push(this.add('get', [ fn.name ]));
+    if (marker) at.args[at.args.length - marker].args[0] = fn.name;
+    else at.args.push(this.add('get', [ fn.name ]));
     this.instructions.push(at);
 
     this.add('async-end', [ at ]);

--- a/lib/spoon/block.js
+++ b/lib/spoon/block.js
@@ -121,8 +121,11 @@ Block.prototype.split = function split(at, root, asyncify, marker) {
   this.ended = false;
 
   if (asyncify) {
-    if (marker) at.args[at.args.length - marker].args[0] = fn.name;
-    else at.args.push(this.add('get', [ fn.name ]));
+    if (marker) {
+      at.args[at.args.length - marker].args[0] = fn.name;
+    } else {
+      at.args.push(this.add('get', [ fn.name ]));
+    }
     this.instructions.push(at);
 
     this.add('async-end', [ at ]);

--- a/lib/spoon/cfg.js
+++ b/lib/spoon/cfg.js
@@ -203,7 +203,11 @@ Cfg.prototype.asyncify = function asyncify(asts, options) {
             instr.uses.length > 0)) {
           return false;
         }
-        if (options.marker && block.fn.root.instr && block.fn.root.instr.params.indexOf('_') < 0) return false;
+        if (options.marker && block.fn.root.instr) {
+          var marker = block.fn.root.instr.params.indexOf('_');
+          if (marker < 0) return false;
+          block.fn.root.instr.params[marker] = '__$callback';
+        }
 
         hasDeclaration[block.id] = block;
         return true;

--- a/lib/spoon/cfg.js
+++ b/lib/spoon/cfg.js
@@ -1034,7 +1034,7 @@ Cfg.prototype.visitFor = function visitFor(ast) {
   });
 };
 
-Cfg.prototype.visitForIn = function visitFor(ast) {
+Cfg.prototype.visitForIn = function visitForIn(ast) {
   var left = ast.left,
       right = ast.right;
 
@@ -1124,7 +1124,7 @@ Cfg.prototype.visitTry = function visitTry(ast) {
   return null;
 };
 
-Cfg.prototype.visitThrow = function visitTry(ast) {
+Cfg.prototype.visitThrow = function visitThrow(ast) {
   this.add('throw', ast.argument ? [ this.visit(ast.argument) ] : []);
   this.current.end();
   return null;
@@ -1138,7 +1138,7 @@ Cfg.prototype.visitNew = function visitNew(ast) {
   }, this)));
 };
 
-Cfg.prototype.visitSwitch = function visitTry(ast) {
+Cfg.prototype.visitSwitch = function visitSwitch(ast) {
   throw new TypeError('Switch is not implemented yet');
   var self = this,
       disc = this.visit(ast.discriminant),

--- a/lib/spoon/cfg.js
+++ b/lib/spoon/cfg.js
@@ -99,13 +99,13 @@ Cfg.prototype.translate = function translate(ast) {
   }
 };
 
-Cfg.prototype.split = function split(at, root, asyncify) {
+Cfg.prototype.split = function split(at, root, asyncify, marker) {
   var block = at.block;
 
   // Do not split same blocks twice
   if (this.asyncifyState[block.id]) return this.asyncifyState[block.id];
 
-  var info = block.split(at, root, asyncify);
+  var info = block.split(at, root, asyncify, marker);
   this.asyncifyState[block.id] = info.fn;
 
   this.roots.push(info.next);
@@ -144,6 +144,14 @@ Cfg.prototype.asyncify = function asyncify(asts, options) {
     assert.equal(ast.body[0].type, 'ExpressionStatement');
     return ast.body[0].expression;
   });
+
+  function markerIndex(instr, marker) {
+    if (!marker) return -1;
+    var args = (instr.type === 'call' && instr.args.slice(1)) || (instr.type === 'method' && instr.args.slice(2));
+    var found = -1;
+    args && args.forEach(function(arg, i) { if (arg.type === 'get' && arg.args[0] === marker) found = args.length - i; });
+    return found;
+  }
 
   // Test whether instr matches 'fn' or not
   function match(instr) {
@@ -195,6 +203,7 @@ Cfg.prototype.asyncify = function asyncify(asts, options) {
             instr.uses.length > 0)) {
           return false;
         }
+        if (options.marker && block.fn.root.instr && block.fn.root.instr.params.indexOf('_') < 0) return false;
 
         hasDeclaration[block.id] = block;
         return true;
@@ -224,10 +233,11 @@ Cfg.prototype.asyncify = function asyncify(asts, options) {
     }
 
     block.instructions.forEach(function(instr) {
-      if (!match(instr)) return;
+      var marker = markerIndex(instr, options.marker);
+      if (marker < 0 && !match(instr)) return;
 
       // Split graph at instruction
-      this.split(instr, instr.block.getRoot(), true);
+      var fn = this.split(instr, instr.block.getRoot(), true, marker);
 
       // Replace all instruction uses by __$r
       instr.uses.forEach(function(use, i) {
@@ -1008,7 +1018,7 @@ Cfg.prototype.visitThis = function visitThis(ast) {
 };
 
 Cfg.prototype.visitFor = function visitFor(ast) {
-  this.visit(ast.init);
+  ast.init && this.visit(ast.init);
 
   return this.enterLoop(function(end, loop) {
     var start = this.current,

--- a/lib/spoon/cfg.js
+++ b/lib/spoon/cfg.js
@@ -147,9 +147,19 @@ Cfg.prototype.asyncify = function asyncify(asts, options) {
 
   function markerIndex(instr, marker) {
     if (!marker) return -1;
-    var args = (instr.type === 'call' && instr.args.slice(1)) || (instr.type === 'method' && instr.args.slice(2));
+    var args;
+    if (instr.type === 'call') {
+      args = instr.args.slice(1);
+    } else if (instr.type === 'method') {
+      args = instr.args.slice(2);
+    }
+    if (!args) return -1;
     var found = -1;
-    args && args.forEach(function(arg, i) { if (arg.type === 'get' && arg.args[0] === marker) found = args.length - i; });
+    args.forEach(function(arg, i) {
+      if (arg.type === 'get' && arg.args[0] === marker) {
+        found = args.length - i;
+      }
+    });
     return found;
   }
 
@@ -204,7 +214,7 @@ Cfg.prototype.asyncify = function asyncify(asts, options) {
           return false;
         }
         if (options.marker && block.fn.root.instr) {
-          var marker = block.fn.root.instr.params.indexOf('_');
+          var marker = block.fn.root.instr.params.indexOf(options.marker);
           if (marker < 0) return false;
           block.fn.root.instr.params[marker] = '__$callback';
         }
@@ -1022,7 +1032,7 @@ Cfg.prototype.visitThis = function visitThis(ast) {
 };
 
 Cfg.prototype.visitFor = function visitFor(ast) {
-  ast.init && this.visit(ast.init);
+  if (ast.init) this.visit(ast.init);
 
   return this.enterLoop(function(end, loop) {
     var start = this.current,

--- a/lib/spoon/renderer.js
+++ b/lib/spoon/renderer.js
@@ -204,6 +204,8 @@ Renderer.prototype.renderInstruction = function renderInstruction(instr) {
     fn = this.renderAsyncReturn;
   } else if (t === 'async-end') {
     fn = this.renderAsyncEnd;
+  } else if (t === 'async-test-err') {
+    fn = this.renderAsyncTestErr;
   } else if (t === 'nop') {
     fn = this.renderNop;
   } else {
@@ -396,7 +398,7 @@ Renderer.prototype.renderNew = function renderNew(args) {
 Renderer.prototype.renderAsyncReturn = function renderAsyncReturn(args) {
   return ['return', ['call',
     ['dot', ['name', '__$callback'], 'call'],
-    [['name', 'this']].concat(args)]];
+    [['name', 'this'],['name', 'null']].concat(args)]];
 };
 
 Renderer.prototype.renderAsyncEnd = function renderAsyncEnd(args) {
@@ -405,6 +407,10 @@ Renderer.prototype.renderAsyncEnd = function renderAsyncEnd(args) {
 
 Renderer.prototype.renderAsyncGoto = function renderAsyncGoto(args) {
   return ['return', ['call', ['dot', args[0], 'call'], [['name', 'this']]]];
+};
+
+Renderer.prototype.renderAsyncTestErr = function renderAsyncTestErr(args) {
+  return ['if', ['name', '__$e'], ['block', [['return', ['call', ['dot', ['name', '__$callback'], 'call'], [['name', 'this'],['name', '__$e']]]]]]];
 };
 
 Renderer.prototype.renderNop = function renderNop() {

--- a/lib/spoon/renderer.js
+++ b/lib/spoon/renderer.js
@@ -410,7 +410,10 @@ Renderer.prototype.renderAsyncGoto = function renderAsyncGoto(args) {
 };
 
 Renderer.prototype.renderAsyncTestErr = function renderAsyncTestErr(args) {
-  return ['if', ['name', '__$e'], ['block', [['return', ['call', ['dot', ['name', '__$callback'], 'call'], [['name', 'this'],['name', '__$e']]]]]]];
+  return ['if', ['name', '__$e'], ['block', 
+    [['return', ['call', 
+    ['dot', ['name', '__$callback'], 'call'], 
+    [['name', 'this'],['name', '__$e']]]]]]];
 };
 
 Renderer.prototype.renderNop = function renderNop() {


### PR DESCRIPTION
The streamline stuff is conditioned by `options.marker` which should be set to '_'. If this option is not set the code should behave as it did before.

I'll probably need to tweak the code a little bit more for streamline but no much more (changes should be one liners). If you don't want the streamline specific stuff in the main library you can just trash it and I'll maintain it in my own fork but it woulld be easier for me to have it in the trunk (or to be able to activate it via special hooks).

I need to enable the _future_ feature to be able to run my unit-tests. It should be easy but I'll do it tomorrow cause it is getting really late here.
